### PR TITLE
First implementation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,1 @@
+{"extends": "standard"}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: Continuous Integration
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [14, 16]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install Dependencies
+        run: npm install --ignore-scripts
+      - name: Run Tests
+        run: npm test
+
+  automerge:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          target: minor

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
-# fast-json-stringify-compiler
-Build and manage the fast-json-stringify instances for the fastify framework
+# @fastify/fast-json-stringify-compiler
+Build and manage the [`fast-json-stringify`](https://www.npmjs.com/package/fast-json-stringify) instances for the fastify framework.
+This package is responsible for compiling the application's `response` JSON schemas into optimized functions to speed up the response time.
+
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
+[![Continuous Integration](https://github.com/fastify/ajv-compiler/workflows/Continuous%20Integration/badge.svg)](https://github.com/fastify/ajv-compiler/actions/workflows/ci.yml)
+
+
+## Versions
+
+| `@fastify/fast-json-stringify-compiler` | `fast-json-stringify` | Default in `fastify` |
+|----------------------------------------:|----------------------:|---------------------:|
+|                                    v1.x |                  v3.x |                 ^4.x |
+
+### fast-json-stringify Configuration
+
+The `fast-json-stringify` configuration is the default one. You can check it the default settings in the [`fast-json-stringify` option](https://github.com/fastify/fast-json-stringify/#options) documentation.
+
+You can also override the default configuration by passing the [`serializerOpts`](https://www.fastify.io/docs/latest/Reference/Server/#serializeropts) configuration to the Fastify instance.
+
+## Usage
+
+This module is already used as default by Fastify.
+If you need to provide to your server instance a different version, refer to [the official doc](https://www.fastify.io/docs/latest/Reference/Server/#schemacontroller).
+
+### How it works
+
+This module provide a factory function to produce [Serializer Compilers](https://www.fastify.io/docs/latest/Reference/Server/#serializercompiler) functions.
+
+## License
+
+Licensed under [MIT](./LICENSE).

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,12 @@
+import { Options as FJSOptions } from 'fast-json-stringify'
+
+export type SerializerCompiler = (
+  externalSchemas: unknown,
+  options: FJSOptions
+) => (doc: any) => string;
+
+export declare function SerializerSelector(): SerializerCompiler;
+
+export type { Options } from 'fast-json-stringify'
+
+export default SerializerSelector;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const fastJsonStringify = require('fast-json-stringify')
+
+function SerializerSelector () {
+  return function buildSerializerFactory (externalSchemas, serializerOpts) {
+    const fjsOpts = Object.assign({}, serializerOpts, { schema: externalSchemas })
+    return responseSchemaCompiler.bind(null, fjsOpts)
+  }
+}
+
+function responseSchemaCompiler (fjsOpts, { schema /* method, url, httpStatus */ }) {
+  return fastJsonStringify(schema, fjsOpts)
+}
+
+module.exports = SerializerSelector

--- a/package.json
+++ b/package.json
@@ -3,8 +3,12 @@
   "description": "Build and manage the fast-json-stringify instances for the fastify framework",
   "version": "1.0.0",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
-    "test": "tap test/*.js"
+    "lint:fix": "standard --fix",
+    "unit": "tap --100 test/**/*.test.js",
+    "test": "standard && npm run unit && npm run test:typescript",
+    "test:typescript": "tsd"
   },
   "repository": {
     "type": "git",
@@ -20,9 +24,13 @@
   "devDependencies": {
     "fastify": "^3.25.3",
     "standard": "^16.0.4",
-    "tap": "^15.1.6"
+    "tap": "^15.1.6",
+    "tsd": "^0.19.1"
   },
   "dependencies": {
     "fast-json-stringify": "^3.0.0"
+  },
+  "tsd": {
+    "directory": "test/types"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@fastify/fast-json-stringify-compiler",
+  "description": "Build and manage the fast-json-stringify instances for the fastify framework",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "tap test/*.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fastify/fast-json-stringify-compiler.git"
+  },
+  "keywords": [],
+  "author": "Manuel Spigolon <manuel.spigolon@nearform.com> (https://github.com/Eomm)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/fastify/fast-json-stringify-compiler/issues"
+  },
+  "homepage": "https://github.com/fastify/fast-json-stringify-compiler#readme",
+  "devDependencies": {
+    "fastify": "^3.25.3",
+    "standard": "^16.0.4",
+    "tap": "^15.1.6"
+  },
+  "dependencies": {
+    "fast-json-stringify": "^3.0.0"
+  }
+}

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,0 +1,80 @@
+'use strict'
+
+const t = require('tap')
+const fastify = require('fastify')
+const FjsCompiler = require('../index')
+
+const echo = async (req, reply) => { return req.body }
+
+const sampleSchema = Object.freeze({
+  $id: 'example1',
+  type: 'object',
+  properties: {
+    name: { type: 'string' }
+  }
+})
+
+const externalSchemas1 = Object.freeze({})
+const externalSchemas2 = Object.freeze({
+  foo: {
+    $id: 'foo',
+    type: 'object',
+    properties: {
+      name: { type: 'string' }
+    }
+  }
+})
+
+const fastifyFjsOptionsDefault = Object.freeze({
+  customOptions: {}
+})
+
+t.test('basic usage', t => {
+  t.plan(1)
+  const factory = FjsCompiler()
+  const compiler = factory(externalSchemas1, fastifyFjsOptionsDefault)
+  const serializeFunc = compiler({ schema: sampleSchema })
+  const result = serializeFunc({ name: 'hello' })
+  t.equal(result, '{"name":"hello"}')
+})
+
+t.test('fastify integration', async t => {
+  const factory = FjsCompiler()
+
+  const app = fastify({
+    serializerOpts: {
+      rounding: 'ceil'
+    },
+    schemaController: {
+      compilersFactory: {
+        buildSerializer: factory
+      }
+    }
+  })
+
+  app.addSchema(externalSchemas2.foo)
+
+  app.post('/', {
+    handler: echo,
+    schema: {
+      response: {
+        200: {
+          $ref: 'foo#'
+        }
+      }
+    }
+  })
+
+  const res = await app.inject({
+    url: '/',
+    method: 'POST',
+    payload: {
+      version: '1',
+      foo: 'this is not a number',
+      name: 'serialize me'
+    }
+  })
+
+  t.equal(res.statusCode, 200)
+  t.same(res.json(), { name: 'serialize me' })
+})

--- a/test/types/index.test.ts
+++ b/test/types/index.test.ts
@@ -1,0 +1,6 @@
+import { expectType } from "tsd";
+import SerializerSelector, { SerializerCompiler } from "../..";
+
+const compiler = SerializerSelector();
+
+expectType<SerializerCompiler>(compiler);


### PR DESCRIPTION
as per https://github.com/fastify/ajv-compiler

this module let us decouple the fjs library from the fastify's core to let the user upgrade sooner (using the `schemaController` feature)

this PR blocks https://github.com/fastify/fastify/pull/3280