### PR TITLE
docs(readme): replace `fastify.io` links with `fastify.dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ This package is responsible for compiling the application's `response` JSON sche
 
 The `fast-json-stringify` configuration is the default one. You can check it the default settings in the [`fast-json-stringify` option](https://github.com/fastify/fast-json-stringify/#options) documentation.
 
-You can also override the default configuration by passing the [`serializerOpts`](https://www.fastify.io/docs/latest/Reference/Server/#serializeropts) configuration to the Fastify instance.
+You can also override the default configuration by passing the [`serializerOpts`](https://www.fastify.dev/docs/latest/Reference/Server/#serializeropts) configuration to the Fastify instance.
 
 ## Usage
 
 This module is already used as default by Fastify.
-If you need to provide to your server instance a different version, refer to [the official doc](https://www.fastify.io/docs/latest/Reference/Server/#schemacontroller).
+If you need to provide to your server instance a different version, refer to [the official doc](https://www.fastify.dev/docs/latest/Reference/Server/#schemacontroller).
 
 ### fast-json-stringify Standalone
 
@@ -120,7 +120,7 @@ app.listen({ port: 3000 })
 
 ### How it works
 
-This module provide a factory function to produce [Serializer Compilers](https://www.fastify.io/docs/latest/Reference/Server/#serializercompiler) functions.
+This module provide a factory function to produce [Serializer Compilers](https://www.fastify.dev/docs/latest/Reference/Server/#serializercompiler) functions.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ This package is responsible for compiling the application's `response` JSON sche
 
 The `fast-json-stringify` configuration is the default one. You can check it the default settings in the [`fast-json-stringify` option](https://github.com/fastify/fast-json-stringify/#options) documentation.
 
-You can also override the default configuration by passing the [`serializerOpts`](https://www.fastify.dev/docs/latest/Reference/Server/#serializeropts) configuration to the Fastify instance.
+You can also override the default configuration by passing the [`serializerOpts`](https://fastify.dev/docs/latest/Reference/Server/#serializeropts) configuration to the Fastify instance.
 
 ## Usage
 
 This module is already used as default by Fastify.
-If you need to provide to your server instance a different version, refer to [the official doc](https://www.fastify.dev/docs/latest/Reference/Server/#schemacontroller).
+If you need to provide to your server instance a different version, refer to [the official doc](https://fastify.dev/docs/latest/Reference/Server/#schemacontroller).
 
 ### fast-json-stringify Standalone
 
@@ -120,7 +120,7 @@ app.listen({ port: 3000 })
 
 ### How it works
 
-This module provide a factory function to produce [Serializer Compilers](https://www.fastify.dev/docs/latest/Reference/Server/#serializercompiler) functions.
+This module provide a factory function to produce [Serializer Compilers](https://fastify.dev/docs/latest/Reference/Server/#serializercompiler) functions.
 
 ## License
 


### PR DESCRIPTION
See https://github.com/fastify/ajv-compiler/pull/115

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
