### PR TITLE
Fix `SerializerCompiler` type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,7 +8,7 @@ declare namespace SerializerSelector {
     options?: Options
   ) => SerializerCompiler
 
-  export type SerializerCompiler = (routeDef: RouteDefinition) => Serializer;
+  export type SerializerCompiler = (routeDef: RouteDefinition) => Serializer
   export type Serializer = (doc: any) => string
 
   export type RouteDefinition = {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,10 +8,7 @@ declare namespace SerializerSelector {
     options?: Options
   ) => SerializerCompiler;
 
-  export type SerializerCompiler = (
-    externalSchemas?: unknown,
-    options?: Options
-  ) => Serializer;
+  export type SerializerCompiler = (routeDef: RouteDefinition) => Serializer;
 
   export type Serializer = (doc: any) => string
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -34,11 +34,11 @@ import SerializerSelector, {
   const externalSchemas1 = {}
 
   const factory = SerializerSelector()
-  expectType<SerializerFactory>(factory);
+  expectType<SerializerFactory>(factory)
   const compiler = factory(externalSchemas1, {})
-  expectType<SerializerCompiler>(compiler);
-  const serializeFunc = compiler({ schema: sampleSchema, method: '', url:'', httpStatus: '' })
-  expectType<Serializer>(serializeFunc);
+  expectType<SerializerCompiler>(compiler)
+  const serializeFunc = compiler({ schema: sampleSchema, method: '', url: '', httpStatus: '' })
+  expectType<Serializer>(serializeFunc)
 
   expectType<string>(serializeFunc({ name: 'hello' }))
 }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -38,7 +38,7 @@ import SerializerSelector, {
     expectType<SerializerFactory>(factory);
     const compiler = factory(externalSchemas1, {})
     expectType<SerializerCompiler>(compiler);
-    const serializeFunc = compiler({ schema: sampleSchema })
+    const serializeFunc = compiler({ schema: sampleSchema, method: '', url:'', httpStatus: '' })
     expectType<Serializer>(serializeFunc);
 
     expectType<string>(serializeFunc({ name: 'hello' }))
@@ -88,6 +88,9 @@ expectType<SerializerFactory>(writer);
   }
 
   const endpointSchema = {
+    method: '',
+    url: '',
+    httpStatus: '',
     schema: {
       $id: 'urn:schema:endpoint',
       $ref: 'urn:schema:ref'


### PR DESCRIPTION
PR for #47 .

A reflexion is that `RouteDefinition` could rather be because in the context of the compiler I think the compiler would never be called if the schema is undefined and most of the time url, method and httpStatus are not used :
```ts
export type RouteDefinition = {
    method?: string;
    url?: string;
    httpStatus?: string;
    schema: unknown;
  }
```

And if used with `reply.getSerializationFunction` or `reply.compileSerializationSchema` they can be undefined : 
> .getSerializationFunction(schema | httpStatus, [contentType]) - Returns the serialization function for the specified schema or http status, if any of either are set.
> .compileSerializationSchema(schema, [httpStatus], [contentType]) - Compiles the specified schema and returns a serialization function using the default (or customized) SerializerCompiler. The optional httpStatus is forwarded to the SerializerCompiler if provided, default to undefined.


What do you think ?
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
