### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/fastify/fast-json-stringify-compiler#readme",
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.12.0",
     "sanitize-filename": "^1.6.3",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.