### PR TITLE
chore: fix doc support version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This package is responsible for compiling the application's `response` JSON sche
 |                                    v1.x |                  v3.x |                ^3.x |
 |                                    v2.x |                  v3.x |                ^4.x |
 |                                    v3.x |                  v4.x |                ^4.x |
-|                                    v4.x |                  v5.x |                ^4.x |
+|                                    v4.x |                  v5.x |                ^5.x |
 
 ### fast-json-stringify Configuration
 


### PR DESCRIPTION
The v5 of this module has been shipped with fastify v5:

https://github.com/fastify/fast-json-stringify-compiler/compare/4.3.0...v5.0.0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519