### PR TITLE
chore(lint): remove legacy .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,1 +1,0 @@
-{"extends": "standard"}


### PR DESCRIPTION
Proposal:

- Removes the legacy `.eslintrc` file, which is now redundant since the project already uses `eslint.config.js` (flat config, ESLint v9).

